### PR TITLE
Bump spire 1.0.0

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -26,7 +26,7 @@ description: |
   ```
 type: application
 version: 0.2.1
-appVersion: "0.12.3"
+appVersion: "1.0.0"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent"]
 home: https://github.com/philips-labs/helm-charts/charts/spire
 sources:

--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -25,7 +25,7 @@ description: |
           - --service-account-signing-key-file=/run/config/pki/sa.key
   ```
 type: application
-version: 0.2.1
+version: 0.3.0
 appVersion: "1.0.0"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent"]
 home: https://github.com/philips-labs/helm-charts/charts/spire

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. -->
 
-![Version: 0.2.1](https://img.shields.io/badge/Version-0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.12.3](https://img.shields.io/badge/AppVersion-0.12.3-informational?style=flat-square)
+![Version: 0.3.0](https://img.shields.io/badge/Version-0.3.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 A Helm chart for deploying spire-server and spire-agent.
 

--- a/charts/spire/templates/server-configmap.yaml
+++ b/charts/spire/templates/server-configmap.yaml
@@ -8,7 +8,7 @@ data:
     server {
       bind_address = "0.0.0.0"
       bind_port = "8081"
-      registration_uds_path = "{{ include "spire.sockets" . }}/registration.sock"
+      socket_path = "{{ include "spire.sockets" . }}/registration.sock"
       trust_domain = {{ .Values.spire.trustDomain | quote }}
       data_dir = "/run/spire/data"
       log_level = "{{ .Values.spire.server.logLevel }}"
@@ -35,7 +35,7 @@ data:
         plugin_data {
           clusters = {
             {{ .Values.spire.clusterName | quote }} = {
-              service_account_whitelist = ["{{ .Release.Namespace }}:{{ include "spire.serviceAccountName" . }}-agent"]
+              service_account_allow_list = ["{{ .Release.Namespace }}:{{ include "spire.serviceAccountName" . }}-agent"]
             }
           }
         }


### PR DESCRIPTION
This PR upgrades the Spire Chart from spire `0.12.3` to `1.0.0`.

Some deprecated configurations have been replaced with the new ones.

See the release notes:

- https://github.com/spiffe/spire/releases/tag/v1.0.0