### PR TITLE
Spire deprecation

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -25,7 +25,7 @@ description: |
           - --service-account-signing-key-file=/run/config/pki/sa.key
   ```
 type: application
-version: 0.3.1
+version: 0.3.2
 appVersion: "1.0.0"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent"]
 home: https://github.com/philips-labs/helm-charts/charts/spire

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. -->
 
-![Version: 0.3.1](https://img.shields.io/badge/Version-0.3.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
+![Version: 0.3.2](https://img.shields.io/badge/Version-0.3.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.0.0](https://img.shields.io/badge/AppVersion-1.0.0-informational?style=flat-square)
 
 A Helm chart for deploying spire-server and spire-agent.
 

--- a/charts/spire/templates/NOTES.txt
+++ b/charts/spire/templates/NOTES.txt
@@ -1,4 +1,4 @@
 1. Get the currently registered SPIFFE entries from the server:
 
   kubectl exec -n {{ .Release.Namespace }} {{ include "spire.fullname" . }}-server-0 -c spire-server -- \
-    bin/spire-server entry show -registrationUDSPath {{ include "spire.sockets" . }}/registration.sock
+    bin/spire-server entry show -socketPath {{ include "spire.sockets" . }}/registration.sock


### PR DESCRIPTION
Resolves the following deprecation notice with the current spire server version.

```shell
kubectl exec -n spire spire-server-0 -c spire-server -- \
    bin/spire-server entry show -registrationUDSPath /run/spire/sockets/registration.sock
warning: -registrationUDSPath is deprecated; use -socketPath
Found 10 entries
…
```