### PR TITLE
Replace wait-for-it image to get rid of vulnerabilities

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -27,7 +27,7 @@ description: |
           - --service-account-signing-key-file=/run/config/pki/sa.key
   ```
 type: application
-version: 0.7.3
+version: 0.7.4
 appVersion: "1.5.2"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc"]
 home: https://github.com/philips-labs/helm-charts/charts/spire

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. -->
 
-![Version: 0.7.3](https://img.shields.io/badge/Version-0.7.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.2](https://img.shields.io/badge/AppVersion-1.5.2-informational?style=flat-square)
+![Version: 0.7.4](https://img.shields.io/badge/Version-0.7.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.2](https://img.shields.io/badge/AppVersion-1.5.2-informational?style=flat-square)
 
 A Helm chart for deploying spire-server and spire-agent.
 
@@ -130,9 +130,9 @@ Kubernetes: `>=1.21.0-0`
 | spire.clusterName | string | `"example-cluster"` |  |
 | spire.trustDomain | string | `"example.org"` |  |
 | waitForIt.image.pullPolicy | string | `"IfNotPresent"` |  |
-| waitForIt.image.registry | string | `"gcr.io"` |  |
-| waitForIt.image.repository | string | `"spiffe-io/wait-for-it"` |  |
-| waitForIt.image.version | string | `""` |  |
+| waitForIt.image.registry | string | `"cgr.dev"` |  |
+| waitForIt.image.repository | string | `"chainguard/wait-for-it"` |  |
+| waitForIt.image.version | string | `"latest-20221215"` |  |
 | waitForIt.resources | object | `{}` |  |
 | workloadRegistrar.image.pullPolicy | string | `"IfNotPresent"` |  |
 | workloadRegistrar.image.registry | string | `"gcr.io"` |  |

--- a/charts/spire/templates/agent-daemonset.yaml
+++ b/charts/spire/templates/agent-daemonset.yaml
@@ -28,7 +28,7 @@ spec:
         - name: init
           # This is a small image with wait-for-it, choose whatever image
           # you prefer that waits for a service to be up. This image is built
-          # from https://github.com/lqhl/wait-for-it
+          # from https://github.com/vishnubob/wait-for-it
           image: {{ template "spire.image" .Values.waitForIt }}
           imagePullPolicy: {{ .Values.waitForIt.image.pullPolicy }}
           args: ["-t", "30", "-h", "{{ include "spire.fullname" . }}-server", "-p", "8081"]

--- a/charts/spire/templates/agent-daemonset.yaml
+++ b/charts/spire/templates/agent-daemonset.yaml
@@ -31,7 +31,7 @@ spec:
           # from https://github.com/lqhl/wait-for-it
           image: {{ template "spire.image" .Values.waitForIt }}
           imagePullPolicy: {{ .Values.waitForIt.image.pullPolicy }}
-          args: ["-t", "30", "{{ include "spire.fullname" . }}-server:8081"]
+          args: ["-t", "30", "-h", "{{ include "spire.fullname" . }}-server", "-p", "8081"]
           resources:
             {{- toYaml .Values.waitForIt.resources | nindent 12 }}
       {{- with .Values.agent.nodeSelector }}

--- a/charts/spire/values.yaml
+++ b/charts/spire/values.yaml
@@ -3,10 +3,10 @@ fullnameOverride: ""
 
 waitForIt:
   image:
-    registry: gcr.io
-    repository: spiffe-io/wait-for-it
+    registry: cgr.dev
+    repository: chainguard/wait-for-it
     pullPolicy: IfNotPresent
-    version: ""
+    version: latest-20221215
   resources: {}
 
 workloadRegistrar:


### PR DESCRIPTION
This image was also outdated (no recent releases) and contains whole bunch of vulnerabilities.
