### PR TITLE
Bump node driver registrat + spire

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -27,8 +27,8 @@ description: |
           - --service-account-signing-key-file=/run/config/pki/sa.key
   ```
 type: application
-version: 0.7.1
-appVersion: "1.5.1"
+version: 0.7.2
+appVersion: "1.5.2"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc"]
 home: https://github.com/philips-labs/helm-charts/charts/spire
 sources:

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -67,9 +67,9 @@ Kubernetes: `>=1.21.0-0`
 | imagePullSecrets | list | `[]` |  |
 | nameOverride | string | `""` |  |
 | nodeDriverRegistrar.image.pullPolicy | string | `"IfNotPresent"` |  |
-| nodeDriverRegistrar.image.registry | string | `"quay.io"` |  |
-| nodeDriverRegistrar.image.repository | string | `"k8scsi/csi-node-driver-registrar"` |  |
-| nodeDriverRegistrar.image.version | string | `"v2.0.1"` |  |
+| nodeDriverRegistrar.image.registry | string | `"registry.k8s.io"` |  |
+| nodeDriverRegistrar.image.repository | string | `"sig-storage/csi-node-driver-registrar"` |  |
+| nodeDriverRegistrar.image.version | string | `"v2.6.2"` |  |
 | nodeDriverRegistrar.resources | object | `{}` |  |
 | oidc.affinity | object | `{}` |  |
 | oidc.config.acme.cacheDir | string | `"/run/spire"` |  |

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. -->
 
-![Version: 0.7.1](https://img.shields.io/badge/Version-0.7.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.1](https://img.shields.io/badge/AppVersion-1.5.1-informational?style=flat-square)
+![Version: 0.7.2](https://img.shields.io/badge/Version-0.7.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.2](https://img.shields.io/badge/AppVersion-1.5.2-informational?style=flat-square)
 
 A Helm chart for deploying spire-server and spire-agent.
 

--- a/charts/spire/templates/agent-daemonset.yaml
+++ b/charts/spire/templates/agent-daemonset.yaml
@@ -105,6 +105,7 @@ spec:
           args: [
             "-csi-address", "/spiffe-csi/csi.sock",
             "-kubelet-registration-path", "/var/lib/kubelet/plugins/csi.spiffe.io/csi.sock",
+            "-health-port", "9809"
           ]
           volumeMounts:
             # The registrar needs access to the SPIFFE CSI driver socket
@@ -114,6 +115,15 @@ spec:
             # directory
             - name: kubelet-plugin-registration-dir
               mountPath: /registration
+          ports:
+            - containerPort: 9809
+              name: healthz
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+            initialDelaySeconds: 5
+            timeoutSeconds: 5
           resources:
             {{- toYaml .Values.nodeDriverRegistrar.resources | nindent 12 }}
       volumes:

--- a/charts/spire/values.yaml
+++ b/charts/spire/values.yaml
@@ -134,10 +134,10 @@ csiDriver:
 
 nodeDriverRegistrar:
   image:
-    registry: quay.io
-    repository: k8scsi/csi-node-driver-registrar
+    registry: registry.k8s.io
+    repository: sig-storage/csi-node-driver-registrar
     pullPolicy: IfNotPresent
-    version: v2.0.1
+    version: v2.6.2
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
- Bump csi-node-driver-registrar to v2.6.2
- Add liveness prove to csi-node-registrar
- Resolve CVE by bumping spire to 1.5.2, see https://github.com/spiffe/spire/releases/tag/v1.5.2
