### PR TITLE
Bump spire to 1.5.3 to fix oidc healthchecks

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -27,8 +27,8 @@ description: |
           - --service-account-signing-key-file=/run/config/pki/sa.key
   ```
 type: application
-version: 0.7.4
-appVersion: "1.5.2"
+version: 0.7.5
+appVersion: "1.5.3"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc"]
 home: https://github.com/philips-labs/helm-charts/charts/spire
 sources:

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. -->
 
-![Version: 0.7.4](https://img.shields.io/badge/Version-0.7.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.2](https://img.shields.io/badge/AppVersion-1.5.2-informational?style=flat-square)
+![Version: 0.7.5](https://img.shields.io/badge/Version-0.7.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.3](https://img.shields.io/badge/AppVersion-1.5.3-informational?style=flat-square)
 
 A Helm chart for deploying spire-server and spire-agent.
 
@@ -82,8 +82,8 @@ Kubernetes: `>=1.21.0-0`
 | oidc.config.logLevel | string | `"info"` |  |
 | oidc.enabled | bool | `false` |  |
 | oidc.image.pullPolicy | string | `"IfNotPresent"` |  |
-| oidc.image.registry | string | `"ghcr.io"` |  |
-| oidc.image.repository | string | `"spiffe/spire-oidc-provider"` |  |
+| oidc.image.registry | string | `"gcr.io"` |  |
+| oidc.image.repository | string | `"spiffe-io/oidc-discovery-provider"` |  |
 | oidc.image.version | string | `""` |  |
 | oidc.insecureScheme.enabled | bool | `false` |  |
 | oidc.insecureScheme.nginx.image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/spire/templates/oidc-deployment.yaml
+++ b/charts/spire/templates/oidc-deployment.yaml
@@ -55,19 +55,18 @@ spec:
             - name: spire-oidc-config
               mountPath: /run/spire/oidc/config/
               readOnly: true
-          # Needs new release of spire to fix the http healthchecks
-          # readinessProbe:
-          #   httpGet:
-          #     path: /ready
-          #     port: health
-          #   initialDelaySeconds: 5
-          #   periodSeconds: 5
-          # livenessProbe:
-          #   httpGet:
-          #     path: /live
-          #     port: health
-          #   initialDelaySeconds: 5
-          #   periodSeconds: 5
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          livenessProbe:
+            httpGet:
+              path: /live
+              port: health
+            initialDelaySeconds: 5
+            periodSeconds: 5
           resources:
             {{- toYaml .Values.oidc.resources | nindent 12 }}
         {{- if .Values.oidc.insecureScheme.enabled }}

--- a/charts/spire/values.yaml
+++ b/charts/spire/values.yaml
@@ -165,10 +165,10 @@ oidc:
   replicaCount: 1
 
   image:
-    # registry: gcr.io
-    # repository: spiffe-io/oidc-discovery-provider
-    registry: ghcr.io
-    repository: spiffe/spire-oidc-provider
+    registry: gcr.io
+    repository: spiffe-io/oidc-discovery-provider
+    # registry: ghcr.io
+    # repository: spiffe/oidc-discovery-provider
     pullPolicy: IfNotPresent
     version: ""
 


### PR DESCRIPTION
Seems 1.5.3 was not released as scratch image, so temporarely switching back to gcr image for oidc.