### PR TITLE
OIDC + CSI image update + server podAnnotations bugfix

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -27,7 +27,7 @@ description: |
           - --service-account-signing-key-file=/run/config/pki/sa.key
   ```
 type: application
-version: 0.7.5
+version: 0.7.6
 appVersion: "1.5.3"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc"]
 home: https://github.com/philips-labs/helm-charts/charts/spire

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. -->
 
-![Version: 0.7.5](https://img.shields.io/badge/Version-0.7.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.3](https://img.shields.io/badge/AppVersion-1.5.3-informational?style=flat-square)
+![Version: 0.7.6](https://img.shields.io/badge/Version-0.7.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.3](https://img.shields.io/badge/AppVersion-1.5.3-informational?style=flat-square)
 
 A Helm chart for deploying spire-server and spire-agent.
 

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -82,8 +82,8 @@ Kubernetes: `>=1.21.0-0`
 | oidc.config.logLevel | string | `"info"` |  |
 | oidc.enabled | bool | `false` |  |
 | oidc.image.pullPolicy | string | `"IfNotPresent"` |  |
-| oidc.image.registry | string | `"gcr.io"` |  |
-| oidc.image.repository | string | `"spiffe-io/oidc-discovery-provider"` |  |
+| oidc.image.registry | string | `"ghcr.io"` |  |
+| oidc.image.repository | string | `"spiffe/oidc-discovery-provider"` |  |
 | oidc.image.version | string | `""` |  |
 | oidc.insecureScheme.enabled | bool | `false` |  |
 | oidc.insecureScheme.nginx.image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -62,7 +62,7 @@ Kubernetes: `>=1.21.0-0`
 | csiDriver.image.pullPolicy | string | `"IfNotPresent"` |  |
 | csiDriver.image.registry | string | `"ghcr.io"` |  |
 | csiDriver.image.repository | string | `"spiffe/spiffe-csi-driver"` |  |
-| csiDriver.image.version | string | `"0.2.0"` |  |
+| csiDriver.image.version | string | `"0.2.1"` |  |
 | csiDriver.resources | object | `{}` |  |
 | fullnameOverride | string | `""` |  |
 | imagePullSecrets | list | `[]` |  |

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -116,6 +116,7 @@ Kubernetes: `>=1.21.0-0`
 | server.image.repository | string | `"spiffe/spire-server"` |  |
 | server.image.version | string | `""` |  |
 | server.nodeSelector."kubernetes.io/arch" | string | `"amd64"` |  |
+| server.podAnnotations | object | `{}` |  |
 | server.podSecurityContext | object | `{}` |  |
 | server.replicaCount | int | `1` |  |
 | server.resources | object | `{}` |  |

--- a/charts/spire/templates/server-statefulset.yaml
+++ b/charts/spire/templates/server-statefulset.yaml
@@ -13,7 +13,7 @@ spec:
       {{- include "spire.server.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.oidc.podAnnotations }}
+      {{- with .Values.server.podAnnotations }}
       annotations:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/charts/spire/values.yaml
+++ b/charts/spire/values.yaml
@@ -131,7 +131,7 @@ csiDriver:
     registry: ghcr.io
     repository: spiffe/spiffe-csi-driver
     pullPolicy: IfNotPresent
-    version: 0.2.0
+    version: 0.2.1
   resources: {}
     # We usually recommend not to specify default resources and to leave this as a conscious
     # choice for the user. This also increases chances charts run on environments with little

--- a/charts/spire/values.yaml
+++ b/charts/spire/values.yaml
@@ -165,10 +165,10 @@ oidc:
   replicaCount: 1
 
   image:
-    registry: gcr.io
-    repository: spiffe-io/oidc-discovery-provider
-    # registry: ghcr.io
-    # repository: spiffe/oidc-discovery-provider
+    # registry: gcr.io
+    # repository: spiffe-io/oidc-discovery-provider
+    registry: ghcr.io
+    repository: spiffe/oidc-discovery-provider
     pullPolicy: IfNotPresent
     version: ""
 

--- a/charts/spire/values.yaml
+++ b/charts/spire/values.yaml
@@ -69,6 +69,8 @@ server:
     port: 8081
     annotations: {}
 
+  podAnnotations: {}
+
   podSecurityContext: {}
     # fsGroup: 2000
 


### PR DESCRIPTION
- Switch oidc image back to static image
- Fix server podAnnotations configurable
- Bump chart version to 0.7.6
- Bump csiDriver to 0.2.1
