### PR TITLE
Fix signing helm releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,9 +40,9 @@ jobs:
           version: v1.13.1
 
       - name: Set up Helm
-        uses: azure/setup-helm@v3.5
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3.5
         with:
-          version: v3.10.2
+          version: v3.10.3
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.4.1
@@ -68,7 +68,7 @@ jobs:
             if [ -z "${pkg:-}" ]; then
               break
             fi
-            helm push "${pkg}" oci://ghcr.io/"${GITHUB_REPOSITORY_OWNER}"/helm-charts > .digest
+            helm push "${pkg}" oci://ghcr.io/"${GITHUB_REPOSITORY_OWNER}"/helm-charts |& tee .digest
             file="${pkg##*/}"       # extracts file name from full directory path
             name="${file%-*}"       # extracts chart name from filename
             digest="$(awk -F "[, ]+" '/Digest/{print $NF}' < .digest)"


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

Looks like your oci release thingy is broken now:

https://github.com/philips-labs/helm-charts/actions/runs/3765117389

This is because helm > v3.10.2 is stopped outputting the digest into a file:

https://github.com/helm/helm/commit/c3a62f7880be8bdc904f2d54c4b0c16a86ec204c

This PR aims to fix this problem.

/cc @marcofranssen 