### PR TITLE
Hotfix spire-server, k8s-workload-registrar, spire-agent, and upstream-ca-secret

### DIFF
--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -3,9 +3,9 @@ name: spire
 description: |
   A Helm chart for deploying spire-server and spire-agent.
 
-  > :warning: Please note this chart requires Projected Service Account Tokens which has to be enabled on your k8s api server.
+  > **Warning**: Please note this chart requires Projected Service Account Tokens which has to be enabled on your k8s api server.
 
-  > :warning: Minimum Spire version is `v1.0.2`.
+  > **Note**: Minimum Spire version is `v1.5.3`.
 
   To enable Projected Service Account Tokens on Docker for Mac/Windows run the following
   command to SSH into the Docker Desktop K8s VM.

--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -27,7 +27,7 @@ description: |
           - --service-account-signing-key-file=/run/config/pki/sa.key
   ```
 type: application
-version: 0.10.1
+version: 0.10.2
 appVersion: "1.5.4"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc"]
 home: https://github.com/philips-labs/helm-charts/charts/spire

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. -->
 
-![Version: 0.10.1](https://img.shields.io/badge/Version-0.10.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.4](https://img.shields.io/badge/AppVersion-1.5.4-informational?style=flat-square)
+![Version: 0.10.2](https://img.shields.io/badge/Version-0.10.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.4](https://img.shields.io/badge/AppVersion-1.5.4-informational?style=flat-square)
 
 A Helm chart for deploying spire-server and spire-agent.
 

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -6,9 +6,9 @@
 
 A Helm chart for deploying spire-server and spire-agent.
 
-> :warning: Please note this chart requires Projected Service Account Tokens which has to be enabled on your k8s api server.
+> **Warning**: Please note this chart requires Projected Service Account Tokens which has to be enabled on your k8s api server.
 
-> :warning: Minimum Spire version is `v1.0.2`.
+> **Note**: Minimum Spire version is `v1.5.3`.
 
 To enable Projected Service Account Tokens on Docker for Mac/Windows run the following
 command to SSH into the Docker Desktop K8s VM.

--- a/charts/spire/charts/spire-agent/README.md
+++ b/charts/spire/charts/spire-agent/README.md
@@ -25,7 +25,6 @@ A Helm chart to install the SPIRE agent.
 | podSecurityContext | object | `{}` |  |
 | resources | object | `{}` |  |
 | securityContext | object | `{}` |  |
-| server.host | string | `"spire-server"` |  |
 | server.port | int | `8081` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` |  |

--- a/charts/spire/charts/spire-agent/templates/_helpers.tpl
+++ b/charts/spire/charts/spire-agent/templates/_helpers.tpl
@@ -72,3 +72,7 @@ Create the name of the service account to use
 {{- printf "%s/%s" .image.registry .image.repository -}}
 {{- end -}}
 {{- end }}
+
+{{- define "spire-server-service" -}}
+{{ include "spire-agent.fullname" . | trimSuffix "-agent" }}-server
+{{- end }}

--- a/charts/spire/charts/spire-agent/templates/_helpers.tpl
+++ b/charts/spire/charts/spire-agent/templates/_helpers.tpl
@@ -72,7 +72,3 @@ Create the name of the service account to use
 {{- printf "%s/%s" .image.registry .image.repository -}}
 {{- end -}}
 {{- end }}
-
-{{- define "spire-server-service" -}}
-{{ include "spire-agent.fullname" . | trimSuffix "-agent" }}-server
-{{- end }}

--- a/charts/spire/charts/spire-agent/templates/configmap.yaml
+++ b/charts/spire/charts/spire-agent/templates/configmap.yaml
@@ -8,7 +8,7 @@ data:
     agent {
       data_dir = "/run/spire"
       log_level = {{ .Values.logLevel | quote }}
-      server_address = {{ (include "spire-server-service" .) | quote }}
+      server_address = "{{ .Release.Name }}-server"
       server_port = {{ .Values.server.port | quote }}
       socket_path = {{ .Values.socketPath | quote }}
       trust_bundle_path = "/run/spire/bundle/bundle.crt"

--- a/charts/spire/charts/spire-agent/templates/configmap.yaml
+++ b/charts/spire/charts/spire-agent/templates/configmap.yaml
@@ -8,7 +8,7 @@ data:
     agent {
       data_dir = "/run/spire"
       log_level = {{ .Values.logLevel | quote }}
-      server_address = {{ .Values.server.host | quote }}
+      server_address = {{ (include "spire-server-service" .) | quote }}
       server_port = {{ .Values.server.port | quote }}
       socket_path = {{ .Values.socketPath | quote }}
       trust_bundle_path = "/run/spire/bundle/bundle.crt"

--- a/charts/spire/charts/spire-agent/templates/daemonset.yaml
+++ b/charts/spire/charts/spire-agent/templates/daemonset.yaml
@@ -35,7 +35,7 @@ spec:
           # from https://github.com/vishnubob/wait-for-it
           image: {{ template "spire-agent.image" .Values.waitForIt }}
           imagePullPolicy: {{ .Values.waitForIt.image.pullPolicy }}
-          args: ["-t", "30", "-h", {{ .Values.server.host | quote }}, "-p", {{ .Values.server.port | quote }}]
+          args: ["-t", "30", "-h", "{{ .Release.Name }}-server", "-p", {{ .Values.server.port | quote }}]
           resources:
             {{- toYaml .Values.waitForIt.resources | nindent 12 }}
       containers:

--- a/charts/spire/charts/spire-agent/values.yaml
+++ b/charts/spire/charts/spire-agent/values.yaml
@@ -60,7 +60,6 @@ trustDomain: example.org
 bundleConfigMap: spire-bundle
 
 server:
-  host: spire-server
   port: 8081
 
 waitForIt:

--- a/charts/spire/charts/spire-server/templates/_helpers.tpl
+++ b/charts/spire/charts/spire-server/templates/_helpers.tpl
@@ -84,3 +84,7 @@ Create the name of the service account to use
 {{- end -}}
 {{- end -}}
 {{- end }}
+
+{{- define "spire-k8s-workload-registrar.fullname" -}}
+{{ include "spire-server.fullname" . | trimSuffix "-server" }}-k8s-workload-registrar
+{{- end }}

--- a/charts/spire/charts/spire-server/templates/_helpers.tpl
+++ b/charts/spire/charts/spire-server/templates/_helpers.tpl
@@ -78,9 +78,9 @@ Create the name of the service account to use
 {{- $root := . }}
 {{- with .Values.upstreamAuthority.disk -}}
 {{- if eq (.secret.create | toString) "true" -}}
-{{ include "spire.fullname" $root }}-upstream-ca
+{{ include "spire-server.fullname" $root }}-upstream-ca
 {{- else -}}
-{{ default (include "spire.fullname" $root) .secret.name }}
+{{ default (include "spire-server.fullname" $root) .secret.name }}
 {{- end -}}
 {{- end -}}
 {{- end }}

--- a/charts/spire/charts/spire-server/templates/configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/configmap.yaml
@@ -40,7 +40,7 @@ data:
         plugin_data {
           clusters = {
             {{ .Values.clusterName | quote }} = {
-              service_account_allow_list = ["{{ .Release.Namespace }}:spire-agent"]
+              service_account_allow_list = ["{{ .Release.Namespace }}:{{ .Release.Name }}-agent"]
             }
           }
         }

--- a/charts/spire/charts/spire-server/templates/k8s-workload-registrar-configmap.yaml
+++ b/charts/spire/charts/spire-server/templates/k8s-workload-registrar-configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ include "spire-server.fullname" . }}-k8s-workload-registrar
+  name: {{ include "spire-k8s-workload-registrar.fullname" . }}
   namespace: {{ .Release.Namespace }}
 data:
   workload-registrar.conf: |

--- a/charts/spire/charts/spire-server/templates/k8s-workload-registrar-roles.yaml
+++ b/charts/spire/charts/spire-server/templates/k8s-workload-registrar-roles.yaml
@@ -39,6 +39,9 @@ rules:
   - apiGroups: [""]
     resources: ["events"]
     verbs: ["create"]
+  - apiGroups: ["coordination.k8s.io"]
+    resources: ["leases"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding

--- a/charts/spire/charts/spire-server/templates/k8s-workload-registrar-roles.yaml
+++ b/charts/spire/charts/spire-server/templates/k8s-workload-registrar-roles.yaml
@@ -4,7 +4,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: {{ include "spire-server.fullname" . }}-k8s-workload-registrar
+  name: {{ include "spire-k8s-workload-registrar.fullname" . }}
 rules:
   - apiGroups: [""]
     resources: ["pods", "nodes", "endpoints"]
@@ -13,11 +13,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: {{ include "spire-server.fullname" . }}-k8s-workload-registrar
+  name: {{ include "spire-k8s-workload-registrar.fullname" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
-  name: {{ include "spire-server.fullname" . }}-k8s-workload-registrar
+  name: {{ include "spire-k8s-workload-registrar.fullname" . }}
 subjects:
   - kind: ServiceAccount
     name: {{ include "spire-server.serviceAccountName" . }}
@@ -26,7 +26,7 @@ subjects:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: {{ include "spire-server.fullname" . }}-k8s-workload-registrar
+  name: {{ include "spire-k8s-workload-registrar.fullname" . }}
   namespace: {{ .Release.Namespace }}
 rules:
   - apiGroups: [""]
@@ -43,11 +43,11 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  name: {{ include "spire-server.fullname" . }}-k8s-workload-registrar
+  name: {{ include "spire-k8s-workload-registrar.fullname" . }}
   namespace: {{ .Release.Namespace }}
 roleRef:
   kind: Role
-  name: {{ include "spire-server.fullname" . }}-k8s-workload-registrar
+  name: {{ include "spire-k8s-workload-registrar.fullname" . }}
   apiGroup: rbac.authorization.k8s.io
 subjects:
   - kind: ServiceAccount

--- a/charts/spire/charts/spire-server/templates/k8s-workload-registrar-service.yaml
+++ b/charts/spire/charts/spire-server/templates/k8s-workload-registrar-service.yaml
@@ -1,0 +1,22 @@
+{{- if eq (.Values.k8sWorkloadRegistrar.enabled | toString) "true" }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "spire-k8s-workload-registrar.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 8 }}
+  {{- end }}
+  labels:
+    {{- include "spire-server.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: https
+      port: 443
+      targetPort: k8s-registrar
+      protocol: TCP
+  selector:
+    {{- include "spire-server.selectorLabels" . | nindent 4 }}
+{{- end }}

--- a/charts/spire/charts/spire-server/templates/statefulset.yaml
+++ b/charts/spire/charts/spire-server/templates/statefulset.yaml
@@ -127,7 +127,7 @@ spec:
         {{- if eq (.Values.k8sWorkloadRegistrar.enabled | toString) "true" }}
         - name: k8s-workload-registrar-config
           configMap:
-            name: {{ include "spire-server.fullname" . }}-k8s-workload-registrar
+            name: {{ include "spire-k8s-workload-registrar.fullname" . }}
         {{- end }}
   volumeClaimTemplates:
     {{- if eq (.Values.dataStorage.enabled | toString) "true" }}

--- a/charts/spire/charts/spire-server/templates/statefulset.yaml
+++ b/charts/spire/charts/spire-server/templates/statefulset.yaml
@@ -85,6 +85,10 @@ spec:
           args:
             - -config
             - /run/spire/k8s-workload-registrar/config/workload-registrar.conf
+          ports:
+            - name: k8s-registrar
+              containerPort: 9443
+              protocol: TCP
           resources:
             {{- toYaml .Values.k8sWorkloadRegistrar.resources | nindent 12 }}
           volumeMounts:


### PR DESCRIPTION
* Fix RBAC permissions k8s-workload-registrar []
* Fix agent connectivity if deployed with different name 
* Bump SPIRE Helm chart to 0.10.2 
* Use correct helper function for upstream-ca-secret 
* Add spire-k8s-registrar service
* Utilize helper function for spire-k8s-workload-registrar 
* Update statement on minimum required spire version

> **Note**: This PR resolves all kind of issues when deploying spire with a different name.
>
> ```shell
> helm diff upgrade -n spire-system --install --values ../.local/spire-values.yaml spire-af654ec spire
> ```