### PR TITLE
Hotfix k8s service dns names for oidc provider

### DIFF
--- a/.github/tests/spire-oidc-insecure/values.yaml
+++ b/.github/tests/spire-oidc-insecure/values.yaml
@@ -1,0 +1,12 @@
+spiffe-oidc-discovery-provider:
+  enabled: true
+
+  insecureScheme:
+    enabled: true
+
+  config:
+    domains:
+      - oidc-discovery.example.org
+
+    acme:
+      tosAccepted: true

--- a/charts/spire/Chart.yaml
+++ b/charts/spire/Chart.yaml
@@ -27,7 +27,7 @@ description: |
           - --service-account-signing-key-file=/run/config/pki/sa.key
   ```
 type: application
-version: 0.11.0
+version: 0.11.1
 appVersion: "1.5.4"
 keywords: ["spiffe", "spire", "spire-server", "spire-agent", "oidc", "spire-controller-manager"]
 home: https://github.com/philips-labs/helm-charts/tree/main/charts/spire

--- a/charts/spire/README.md
+++ b/charts/spire/README.md
@@ -2,7 +2,7 @@
 
 <!-- This README.md is generated. -->
 
-![Version: 0.11.0](https://img.shields.io/badge/Version-0.11.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.4](https://img.shields.io/badge/AppVersion-1.5.4-informational?style=flat-square)
+![Version: 0.11.1](https://img.shields.io/badge/Version-0.11.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.5.4](https://img.shields.io/badge/AppVersion-1.5.4-informational?style=flat-square)
 
 A Helm chart for deploying spire-server and spire-agent.
 

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/templates/configmap.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/templates/configmap.yaml
@@ -10,7 +10,8 @@ data:
 
     domains = [
       "{{ include "spiffe-oidc-discovery-provider.fullname" . }}",
-      "{{ include "spiffe-oidc-discovery-provider.fullname" . }}.svc.cluster.local",
+      "{{ include "spiffe-oidc-discovery-provider.fullname" . }}.{{ .Release.Namespace }}",
+      "{{ include "spiffe-oidc-discovery-provider.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local",
     {{- if gt (len .Values.config.domains) 0 }}
       "{{- join "\",\n      \"" .Values.config.domains }}"
     {{- end }}

--- a/charts/spire/charts/spiffe-oidc-discovery-provider/templates/tests/test-connection.yaml
+++ b/charts/spire/charts/spiffe-oidc-discovery-provider/templates/tests/test-connection.yaml
@@ -8,8 +8,16 @@ metadata:
     "helm.sh/hook": test
 spec:
   containers:
-    - name: wget
+    - name: wget-service-name
       image: busybox
       command: ['wget']
-      args: ['{{ include "spiffe-oidc-discovery-provider.fullname" . }}:{{ .Values.service.port }}']
+      args: ['{{ include "spiffe-oidc-discovery-provider.fullname" . }}:{{ .Values.service.port }}/.well-known/openid-configuration']
+    - name: wget-service-name-namespace
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "spiffe-oidc-discovery-provider.fullname" . }}.{{ .Release.Namespace }}:{{ .Values.service.port }}/.well-known/openid-configuration']
+    - name: wget-service-name-namespace-svc-cluster-local
+      image: busybox
+      command: ['wget']
+      args: ['{{ include "spiffe-oidc-discovery-provider.fullname" . }}.{{ .Release.Namespace }}.svc.cluster.local:{{ .Values.service.port }}/.well-known/openid-configuration']
   restartPolicy: Never


### PR DESCRIPTION
- Add the namespace to the oidc-discovery-provider allowed dns names
- Bump SPIRE Helm chart to 0.11.1
- Add test for oidc discovery provider
