### PR TITLE
improve spiffe csi security

### DIFF
--- a/charts/spire/charts/spiffe-csi-driver/templates/daemonset.yaml
+++ b/charts/spire/charts/spiffe-csi-driver/templates/daemonset.yaml
@@ -56,6 +56,10 @@ spec:
               mountPropagation: Bidirectional
               name: mountpoint-dir
           securityContext:
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - all
             privileged: true
           resources:
             {{- toYaml .Values.resources | nindent 12 }}


### PR DESCRIPTION
Improve spiffe-csi-driver securityContext

Ignore the chart version not being incremented. With #114 we will release this in one go.